### PR TITLE
feat: add lock auto report keystone situation

### DIFF
--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -22,3 +22,5 @@ L["msgToggleMPlusAutoReply"] = "<Keystone Runner> Mythic+ auto reply Enabled : %
 L["msgToggleKeyAutoReply"] = "<Keystone Runner> Key auto reply Enabled : %s"
 L["msgUnknownOptCmd"] = "<Keystone Runner> Unknown option command"
 L["msgNoKeystone"] = "(No keystone stored)"
+-- others
+L["msgDontSpam"] = "<Keystone Runner> Enough already.(Irritated) <Auto report keystones(#key) is not available to me for a short time>"

--- a/locales/zhTW.lua
+++ b/locales/zhTW.lua
@@ -22,3 +22,5 @@ L["msgToggleMPlusAutoReply"] = "<Keystone Runner> 允許大秘境挑戰時自動
 L["msgToggleKeyAutoReply"] = "<Keystone Runner> 允許自動回覆 #key 指令：%s"
 L["msgUnknownOptCmd"] = "<Keystone Runner> 無效的選項指令"
 L["msgNoKeystone"] = "(沒有鑰石記錄)"
+-- others
+L["msgDontSpam"] = "<Keystone Runner> 這就是好奇的代價！(對你施放沈默)<短時間內無法再使用自動報告鑰石功能打擾我>"


### PR DESCRIPTION
加入自動報告鑰石的次數限制

規則為五分鐘內只能詢問三次(由第一次時間起算)，第三次時會額外帶出警告訊息(?)並封鎖對方對自己使用其功能的自動回覆機制15分鐘。(只限密語類功能，小隊內不在此限)

註1：英文版我實在找不到什麼好台詞...就找個一直連點npc會有的反應XD

註2：版號部分與改版訊息等你確定完功能沒問題再新增吧，我覺得應該由你更新比較好: )